### PR TITLE
Fixes for the website (URLs and typos)

### DIFF
--- a/bot.md
+++ b/bot.md
@@ -195,7 +195,7 @@ At the moment, *CEbot* supports 8 architectures with the following setup.
 
 - **How this works?**
 
-  Our bot with the Twitter ID **@CEb0t** watches for Twitter stream with hashtags *#2ce* and *#cebot* to pick up the requests. Powered by the latest [Capstone Engine](https://github.com/aquynh/capstone/tree/next), this bot reverses the input hex-string, then sends back the assembly to the user via Twitter.
+  Our bot with the Twitter ID **@CEb0t** watches for Twitter stream with hashtags *#2ce* and *#cebot* to pick up the requests. Powered by the latest [Capstone Engine](https://github.com/capstone-engine/capstone/tree/next), this bot reverses the input hex-string, then sends back the assembly to the user via Twitter.
 
   Note that the input code is disassembled with *offset 0*.
 

--- a/contact.md
+++ b/contact.md
@@ -14,9 +14,9 @@ Want to let us know you are happily using Capstone for your products/training/wo
 
 - [Mailing list](https://lists.sourceforge.net/lists/listinfo/capstone-users) would be the best method to contact us. This is the place for long conversations.
 
-- [Fork the code](https://github.com/aquynh/capstone) to contribute bugfixes and new features - then send us the pull requests.
+- [Fork the code](https://github.com/capstone-engine/capstone) to contribute bugfixes and new features - then send us the pull requests.
 
-- [Github issue](https://github.com/aquynh/capstone/issues/new) is also a good place to report bugs (Note: Github ID required).
+- [Github issue](https://github.com/capstone-engine/capstone/issues/new) is also a good place to report bugs (Note: Github ID required).
 
 - [Twitter](http://twitter.com/capstone_engine) can be used for simple/quick questions -- we will answer in our spare time. 
 

--- a/diet.md
+++ b/diet.md
@@ -14,9 +14,9 @@ Later part presents the APIs related to this feature and recommends the areas pr
 
 Typically, we use Capstone for usual applications, where the library weight does not really matter. Indeed, as of version *2.1-RC1*, the whole engine is only 1.9 MB including all architectures, and this size raises no issue to most people.
 
-However, there are cases when we want to embed Capstone into special enviroments, such as OS kernel driver or firmware, where its size should be as small as possible due to space restriction. While we can always [compile only selected architectures](compile.html) to make the libraries more compact, we still want to slim them down further.
+However, there are cases when we want to embed Capstone into special environments, such as OS kernel driver or firmware, where its size should be as small as possible due to space restriction. While we can always [compile only selected architectures](compile.html) to make the libraries more compact, we still want to slim them down further.
 
-Towards this object, since verson *2.1*, Capstone supports *diet* mode, in which some non-critical data are removed, thus making the engine size at least 40% smaller.
+Towards this object, since version *2.1*, Capstone supports *diet* mode, in which some non-critical data are removed, thus making the engine size at least 40% smaller.
 
 By default, Capstone is built in standard mode. To build *diet* engine, do: (demonstration is on \*nix systems)
 
@@ -92,11 +92,11 @@ While most Capstone APIs are still function exactly the same, due to these absen
 
 - **cs_reg_read()**
 
-  We no longer have information about registers implicitly readed by instructions, so we cannot tell if an instruction read a particular register.
+  We no longer have information about registers implicitly read by instructions, so we cannot tell if an instruction read a particular register.
 
 - **cs_write_read()**
 
-  We no longer have information about registers implicitly readed by instructions, so we cannot tell if an instruction modify a particular register.
+  We no longer have information about registers implicitly read by instructions, so we cannot tell if an instruction modify a particular register.
 
 <br>
 By *irrelevant*, we mean above APIs would return undefined value. Therefore, programmers have been warned *not to use these APIs* in *diet* mode.

--- a/documentation.md
+++ b/documentation.md
@@ -183,7 +183,7 @@ At the moment precompiled binaries for *Windows*, *Ubuntu*, *FedoraCore*, *Pytho
 
 - **Java** <img src="img/jar.png" height="24" width="24">
 
-  Java binding is availabe in JAR package in [Download](download.html).
+  Java binding is available in JAR package in [Download](download.html).
 
 ---
 

--- a/download.md
+++ b/download.md
@@ -18,9 +18,9 @@ See the [version history](changelog.html) for a list of changes.
 
 ### Git repository <img src="img/octocat.jpg" height="32" width="32">
 
-The latest version of the source code can be retrieved at our [Git repository](https://github.com/aquynh/capstone).
+The latest version of the source code can be retrieved at our [Git repository](https://github.com/capstone-engine/capstone).
 
-Refer to the [Wiki Changelog](https://github.com/aquynh/capstone/wiki/ChangeLog) of our development branch to peek into the features of the *next release*.
+Refer to the [Wiki Changelog](https://github.com/capstone-engine/capstone/wiki/ChangeLog) of our development branch to peek into the features of the *next release*.
 
 ---
 
@@ -32,17 +32,17 @@ At the moment Capstone are available for *Mac OSX*, *Ubuntu*, *Debian*, *Fedora 
 
 ### Source archive <img src="img/tgz.png" height="28" width="28"> <img src="img/zip.png" height="32" width="32">
 
-<a class="download" href="https://github.com/aquynh/capstone/archive/{{ post.title }}.tar.gz" title="Download source (TGZ)">.TGZ</a>
+<a class="download" href="https://github.com/capstone-engine/capstone/archive/{{ post.title }}.tar.gz" title="Download source (TGZ)">.TGZ</a>
 
 This package contains:
 
 - The complete source code for the Capstone framework.
-- Bindings for Java & Python (at the moment, Ocaml binding is only available in the [Git repository](https://github.com/aquynh/capstone)).
+- Bindings for Java, Python, Ocaml, PowerShell and VB6.
 - A collection of example and test programs.
 
 This is the recommended version for all platforms.
 
-<a class="download" href="https://github.com/aquynh/capstone/archive/{{ post.title }}.zip" title="Download source (ZIP)">.ZIP</a>
+<a class="download" href="https://github.com/capstone-engine/capstone/archive/{{ post.title }}.zip" title="Download source (ZIP)">.ZIP</a>
 
 ---
 
@@ -74,7 +74,7 @@ Besides PowerShell, Python, Java & Ocaml get supported in the main code, some bi
 
 ### Windows - Core engine <img src="img/windows.png" height="28" width="28">
 
-<a class="download" href="https://github.com/aquynh/capstone/releases/download/{{ post.title }}/capstone-{{ post.title }}-win32.zip" title="Download Win32 Binaries (ZIP)">Win-32</a>
+<a class="download" href="https://github.com/capstone-engine/capstone/releases/download/{{ post.title }}/capstone-{{ post.title }}-win32.zip" title="Download Win32 Binaries (ZIP)">Win-32</a>
 
 NOTE: This is necessary for all bindings (except Python) & also for C programming.
 
@@ -85,7 +85,7 @@ This package contains:
 - 32-bit/64-bit DLLs & static libraries for Microsoft Windows 32-bit/64-bit.
 - cstool (cstool.exe)
 
-<a class="download" href="https://github.com/aquynh/capstone/releases/download/{{ post.title }}/capstone-{{ post.title }}-win64.zip" title="Download Win64 Binaries (ZIP)">Win-64</a>
+<a class="download" href="https://github.com/capstone-engine/capstone/releases/download/{{ post.title }}/capstone-{{ post.title }}-win64.zip" title="Download Win64 Binaries (ZIP)">Win-64</a>
 
 ---
 

--- a/embed.md
+++ b/embed.md
@@ -12,7 +12,7 @@ This documentation introduces necessary steps to build Capstone for embedding in
 
 Typically, we use Capstone for usual applications, where the library weight does not really matter. Indeed, as of version *2.1-RC1*, the whole engine is only 1.9 MB including all architectures, and this size raise no issue to most people.
 
-However, to embed Capstone into special enviroments, such as OS kernel driver or firmware, the engine size should be as small as possible due to space restriction. To achieve this object, we must compile Capstone using special methods.
+However, to embed Capstone into special environments, such as OS kernel driver or firmware, the engine size should be as small as possible due to space restriction. To achieve this object, we must compile Capstone using special methods.
 
 To build a minimize engine, consult two documentations below.
 
@@ -38,7 +38,7 @@ NOTE: the observant readers might already see that we can combine step (1) & (2)
 
 ### 3. Setting up dynamic memory management
 
-In step (2) above, we already specified at compile-time that we will use our own dynamic memory management functions, provided by our embedded enviroment. Next, we need to declare these functions.
+In step (2) above, we already specified at compile-time that we will use our own dynamic memory management functions, provided by our embedded environment. Next, we need to declare these functions.
 
 Capstone needs the following functions: *malloc*, *calloc*, *realloc*, *free* & *vsnprintf*. Unsurprisingly, these functions use exactly the same prototypes of system functions in style of *Unix stdlibc*, like below.
 
@@ -77,7 +77,7 @@ void *my_realloc(void *ptr, size_t size)
 
 void  my_free(void *ptr)
 {
-    // Free memory formely allocated by my_malloc/my_calloc/my_realloc.
+    // Free memory formerly allocated by my_malloc/my_calloc/my_realloc.
     // ...
 }
 

--- a/iteration.md
+++ b/iteration.md
@@ -49,6 +49,6 @@ See below for a sample C code demonstrating this API.
 
 Internally, *cs_disasm_iter* behaves exactly like *cs_disasm* if we call *cs_disasm* with argument *count = 1*. However, *cs_disasm_iter* is faster because it reuses (and also overwrites) the same memory to store disassembled instruction, avoiding all the malloc/realloc in the loop above. So if we just need to do some quick iteration through all the instructions, *cs_disasm_iter* should be considered.
 
-On the other hand, *cs_disasm* is more approriate when we want to disassemble all the instructions (using *count = 0*), or when we want to save all the disassembled instructions - without overwriting them in the loop - for future reference.
+On the other hand, *cs_disasm* is more appropriate when we want to disassemble all the instructions (using *count = 0*), or when we want to save all the disassembled instructions - without overwriting them in the loop - for future reference.
 
 See a full sample of *cs_disasm_iter* & *cs_malloc* in [https://github.com/capstone-engine/capstone/blob/next/tests/test_iter.c](https://github.com/capstone-engine/capstone/blob/next/tests/test_iter.c)

--- a/iteration.md
+++ b/iteration.md
@@ -51,4 +51,4 @@ Internally, *cs_disasm_iter* behaves exactly like *cs_disasm* if we call *cs_dis
 
 On the other hand, *cs_disasm* is more approriate when we want to disassemble all the instructions (using *count = 0*), or when we want to save all the disassembled instructions - without overwriting them in the loop - for future reference.
 
-See a full sample of *cs_disasm_iter* & *cs_malloc* in [https://github.com/aquynh/capstone/blob/next/tests/test_iter.c](https://github.com/aquynh/capstone/blob/next/tests/test_iter.c)
+See a full sample of *cs_disasm_iter* & *cs_malloc* in [https://github.com/capstone-engine/capstone/blob/next/tests/test_iter.c](https://github.com/capstone-engine/capstone/blob/next/tests/test_iter.c)

--- a/lang_c.md
+++ b/lang_c.md
@@ -374,5 +374,5 @@ From version 2.1, Capstone supports "diet" compilation option to minimize the en
 
 ### 7. More examples
 
-This tutorial does not explain all the API of Capstone yet. Please find more advanced examples in source of *test_\*.c* files under directory [tests/](https://github.com/aquynh/capstone/tree/master/tests) in the Capstone source code.
+This tutorial does not explain all the API of Capstone yet. Please find more advanced examples in source of *test_\*.c* files under directory [tests/](https://github.com/capstone-engine/capstone/tree/master/tests) in the Capstone source code.
 

--- a/lang_java.md
+++ b/lang_java.md
@@ -112,5 +112,5 @@ md.setDetail(false)
 
 ### 4. More examples
 
-This tutorial does not explain all the API of Capstone yet. Please find more advanced examples in source of *Test\*.java* files under Java binding directory [bindings/java](https://github.com/aquynh/capstone/tree/master/bindings/java) in the Capstone source code.
+This tutorial does not explain all the API of Capstone yet. Please find more advanced examples in source of *Test\*.java* files under Java binding directory [bindings/java](https://github.com/capstone-engine/capstone/tree/master/bindings/java) in the Capstone source code.
 

--- a/lang_python.md
+++ b/lang_python.md
@@ -347,5 +347,5 @@ From version 2.1, Capstone supports "diet" compilation option to minimize the en
 
 ### 8. More examples
 
-This tutorial does not explain all the API of Capstone yet. Please find more advanced examples in source of *test_\*.py* files under Python binding directory [bindings/python](https://github.com/aquynh/capstone/tree/master/bindings/python) in the Capstone source code.
+This tutorial does not explain all the API of Capstone yet. Please find more advanced examples in source of *test_\*.py* files under Python binding directory [bindings/python](https://github.com/capstone-engine/capstone/tree/master/bindings/python) in the Capstone source code.
 

--- a/mnemonic.md
+++ b/mnemonic.md
@@ -9,7 +9,7 @@ title: Customize instruction mnemonic
 
 In some architectures, an instruction might have alternative mnemonic. Example is the *JNE* instruction on *X86*: this is also called *JNZ* by some disassemblers. The problem is that all the mnemonics are fixed in the engine and cannot be customized. For this reason, some disassembly tools built on top of Capstone have to use some tricks to modify mnemonics at the output for what they desire.
 
-This has been changed with a new option **CS\_OPT\_MNEMONIC** (available in the Github branch [next](https://github.com/aquynh/capstone/tree/next) now, and will be ready when version *4.0* is out). Use this option with *cs_option()* to customize instruction mnemonics, as in the sample C code below.
+This has been changed with a new option **CS\_OPT\_MNEMONIC** (available in the Github branch [next](https://github.com/capstone-engine/capstone/tree/next) now, and will be ready when version *4.0* is out). Use this option with *cs_option()* to customize instruction mnemonics, as in the sample C code below.
 
 <br>
 
@@ -79,7 +79,7 @@ md.mnemonic_setup(X86_INS_JNE, None)
 
 ### 3. More examples
 
-Find the full samples on how to use *CS\_OPT\_MNEMONIC* in the source of [test_x86.c](https://github.com/aquynh/capstone/blob/next/tests/test_customized_mnem.c) or [test_x86.py](https://github.com/aquynh/capstone/blob/next/bindings/python/test_customized_mnem.py).
+Find the full samples on how to use *CS\_OPT\_MNEMONIC* in the source of [test_x86.c](https://github.com/capstone-engine/capstone/blob/next/tests/test_customized_mnem.c) or [test_x86.py](https://github.com/capstone-engine/capstone/blob/next/bindings/python/test_customized_mnem.py).
 
 <br>
 When running these samples, the output is as follows.

--- a/mnemonic.md
+++ b/mnemonic.md
@@ -31,7 +31,7 @@ Below is the explanation for important lines of the above C sample.
 
 - Line 4: Declare variables *my_mnem* of data type *cs\_opt\_mnem* to customize *JNE* instruction (indicated by *X86\_INS\_JNE*) to have mnemonic *"jnz"*.
 
-- Line 6: Intialize X86 engine of 32-bit mode.
+- Line 6: Initialize X86 engine of 32-bit mode.
 
 - Line 7: Call *cs_option* with option *CS\_OPT\_MNEMONIC*, and pass the address of *my_mnem* in the third parameter. After this, we can start disassembling and instruction *JNE* will have *"jnz"* mnemonic, rather than the default value *"jne"*.
 

--- a/op_access.md
+++ b/op_access.md
@@ -90,7 +90,7 @@ Below is the explanation for important lines of the above C sample.
 
 - Line 12: Declare variables *regs_read* & *regs_write* of data type *cs\_regs* to keep the list of registers being read or modified later. Note that *cs\_regs* is actually a data type of an array of *uint16_t*.
 
-- Line 15 ~ 18: Intialize X86 engine, then turn on the *DETAIL* mode, which is required to get the access information of operands & registers.
+- Line 15 ~ 18: Initialize X86 engine, then turn on the *DETAIL* mode, which is required to get the access information of operands & registers.
 
 - Line 20 ~ 24: Disassemble input code, then print out the assembly of all the instructions.
 
@@ -132,7 +132,7 @@ for insn in md.disasm(code, 0x1000):
 <br>
 Below is the explanation for important lines of this Python sample.
 
-- Line 5 ~ 6: Intialize X86 engine, then turn on the *DETAIL* mode, which is required to get the access information of operands & registers.
+- Line 5 ~ 6: Initialize X86 engine, then turn on the *DETAIL* mode, which is required to get the access information of operands & registers.
 
 - Line 8 ~ 9: Disassemble input code, then print out the assembly of all the instructions.
 

--- a/op_access.md
+++ b/op_access.md
@@ -7,7 +7,7 @@ title: Access information of operands.
 
 ### 1. Get access info of registers
 
-Now available in the Github branch [next](https://github.com/aquynh/capstone/tree/next), Capstone provides a new API named **cs\_regs\_access()**. This function can retrieve the list of all registers *read* or *modified* - either implicitly or explicitly - by instructions.
+Now available in the Github branch [next](https://github.com/capstone-engine/capstone/tree/next), Capstone provides a new API named **cs\_regs\_access()**. This function can retrieve the list of all registers *read* or *modified* - either implicitly or explicitly - by instructions.
 
 <br>
 The C sample code below demonstrates how to use *cs\_regs\_access* on X86 input.
@@ -195,5 +195,5 @@ See the screenshot below for what this feature can provide.
 
 ### 4. More examples
 
-Find the full sample on how to retrieve information on operand access in source of [test_x86.c](https://github.com/aquynh/capstone/blob/next/tests/test_x86.c) or [test_x86.py](https://github.com/aquynh/capstone/blob/next/bindings/python/test_x86.py).
+Find the full sample on how to retrieve information on operand access in source of [test_x86.c](https://github.com/capstone-engine/capstone/blob/next/tests/test_x86.c) or [test_x86.py](https://github.com/capstone-engine/capstone/blob/next/bindings/python/test_x86.py).
 

--- a/showcase.md
+++ b/showcase.md
@@ -205,7 +205,7 @@ In our knowledge, Capstone has been used by **508** following products (listed i
 
 - [MemoryPatchDetector](https://github.com/Intezer/MemoryPatchDetector): Detects code differentials between executables in disk and processes/modules in memory.
 
-- [Mpesm](https://github.com/carbonblack/tic/tree/master/mpesm): Indentify the compiler/packer/cryptor of PE files.
+- [Mpesm](https://github.com/carbonblack/tic/tree/master/mpesm): Identify the compiler/packer/cryptor of PE files.
 
 - [Silicon-disassembler](https://github.com/m4b/silicon-disassembler): A high-performance, asynchronous web-component disassembler.
 
@@ -375,7 +375,7 @@ In our knowledge, Capstone has been used by **508** following products (listed i
 
 - [KlareDbg](https://github.com/KernelAnalysisPlatform/KlareDbg): Kernel debugger using Timeless Debugging method.
 
-- [Ponce](https://github.com/illera88/Ponce): IDA Pro-based symbolic execution & taint anlysis engine.
+- [Ponce](https://github.com/illera88/Ponce): IDA Pro-based symbolic execution & taint analysis engine.
 
 - [Relyze](https://www.relyze.com): Interactive Software Analysis.
 
@@ -753,7 +753,7 @@ In our knowledge, Capstone has been used by **508** following products (listed i
 
 - [Pimp my ride](https://github.com/smuniz/pimp_my_ride): Multi-architecture CPU Emulator.
 
-- [PTfuzzer](https://github.com/hunter-ht-2018/ptfuzzer): Greybox fuzzer to fuzz any binary-only softwares.
+- [PTfuzzer](https://github.com/hunter-ht-2018/ptfuzzer): Greybox fuzzer to fuzz any binary-only software.
 
 - [CAFA](https://github.com/CAFA1/CAFA): A Checksum-Aware Fuzzing Assistant For More Coverage.
 
@@ -987,7 +987,7 @@ In our knowledge, Capstone has been used by **508** following products (listed i
 
 - [QuickPatch](https://github.com/Jormit/zdb): GDB plugin for patching ELF file.
 
-- [S(gx)ELF-respect](https://github.com/StanPlatinum/elf-respect): Privacy-preserving TEE protoype on a service-oriented environment.
+- [S(gx)ELF-respect](https://github.com/StanPlatinum/elf-respect): Privacy-preserving TEE prototype on a service-oriented environment.
 
 - [EFI DXE Emulator](https://github.com/gdbinit/efi_dxe_emulator): EFI DXE Emulator and Interactive Debugger.
 
@@ -1005,7 +1005,7 @@ In our knowledge, Capstone has been used by **508** following products (listed i
 
 - [e9patch](https://github.com/GJDuck/e9patch): A Powerful Static Binary Rewriter.
 
-- [specrop](https://github.com/HexHive/specrop/): Speculative exploition of ROP chains.
+- [specrop](https://github.com/HexHive/specrop/): Speculative exploitation of ROP chains.
 
 - [BlindSide](https://github.com/vusec/blindside): BlindSide allows attackers to “hack blind” in the Spectre era.
 

--- a/skipdata.md
+++ b/skipdata.md
@@ -5,7 +5,7 @@ title: SKIPDATA mode
 
 ## SKIPDATA mode
 
-(Note: at the moment, this option is only availabe in the [next branch](https://github.com/aquynh/capstone/tree/next) of our Github repo. It will be integrated into the next release of Capstone)
+(Note: at the moment, this option is only availabe in the [next branch](https://github.com/capstone-engine/capstone/tree/next) of our Github repo. It will be integrated into the next release of Capstone)
 
 By default, Capstone stops disassembling when it encounters a broken instruction. Most of the time, the reason is that this is data mixed inside the input, and it is understandable that Capstone does not understand this "weird" code.
 
@@ -189,6 +189,6 @@ md.skipdata = True
 
 ### 4. Sample code for SKIPDATA mode
 
-For sample C code, see [https://github.com/aquynh/capstone/blob/next/tests/test_skipdata.c](https://github.com/aquynh/capstone/blob/next/tests/test_skipdata.c)
+For sample C code, see [https://github.com/capstone-engine/capstone/blob/next/tests/test_skipdata.c](https://github.com/capstone-engine/capstone/blob/next/tests/test_skipdata.c)
 
-For sample Python code, see [https://github.com/aquynh/capstone/blob/next/bindings/python/test_skipdata.py](https://github.com/aquynh/capstone/blob/next/bindings/python/test_skipdata.py)
+For sample Python code, see [https://github.com/capstone-engine/capstone/blob/next/bindings/python/test_skipdata.py](https://github.com/capstone-engine/capstone/blob/next/bindings/python/test_skipdata.py)

--- a/skipdata.md
+++ b/skipdata.md
@@ -5,11 +5,11 @@ title: SKIPDATA mode
 
 ## SKIPDATA mode
 
-(Note: at the moment, this option is only availabe in the [next branch](https://github.com/capstone-engine/capstone/tree/next) of our Github repo. It will be integrated into the next release of Capstone)
+(Note: at the moment, this option is only available in the [next branch](https://github.com/capstone-engine/capstone/tree/next) of our Github repo. It will be integrated into the next release of Capstone)
 
 By default, Capstone stops disassembling when it encounters a broken instruction. Most of the time, the reason is that this is data mixed inside the input, and it is understandable that Capstone does not understand this "weird" code.
 
-Typically, you are recommended to dertermine yourself where the next code is, and then continue disassembling from that place. However, in some cases you just want to let Capstone automatically skip some data until it finds a legitimate instruction, then just carries on from there. Hence, the **SKIPDATA** mode is introduced for this purpose.
+Typically, you are recommended to determine yourself where the next code is, and then continue disassembling from that place. However, in some cases you just want to let Capstone automatically skip some data until it finds a legitimate instruction, then just carries on from there. Hence, the **SKIPDATA** mode is introduced for this purpose.
 
 In general, this solution is suboptimal because Capstone can make a mistake deciding what is data, what is code. Only rely on a fact that input can be disassembled to determine the code start from there is fundamentally wrong, so you are warned: only use this mode when you know what you are doing.
 

--- a/testimonial.md
+++ b/testimonial.md
@@ -113,7 +113,7 @@ thrilled when Capstone offered to maintain SystemZ disassembly support into
 Capstone. Not only the disassembly is sound and accurate (being derived
 from LLVM's specifications), but it's also fully open source. Best of
 all, we could leverage previous work done with Capstone to craft our own
-disassembly tools targetting SystemZ. Just plain awesome! A warm thank
+disassembly tools targeting SystemZ. Just plain awesome! A warm thank
 to the Capstone community :) 
 >
 <p style="text-align: right"><i>Jonathan Brossard, Toucan System</i></p>
@@ -130,7 +130,7 @@ to the Capstone community :)
 >
 <p style="text-align: right"><i>Joshua Pitts, Tool: "The Backdoor Factory"</i></p>
 
-> And there is ... Capstone! Cool, lightweight, open-source, LLVM-based dissasembly engine for various architectures (x86, arm and many others!) and available to use in different languages like Python, Go, C++! Its small size and high modularity makes it perfectly working in kernel as well! 
+> And there is ... Capstone! Cool, lightweight, open-source, LLVM-based disassembly engine for various architectures (x86, arm and many others!) and available to use in different languages like Python, Go, C++! Its small size and high modularity makes it perfectly working in kernel as well! 
 >
 > Its community is growing, and developers of Capstone provide great support! Thank you guys for providing great tool!
 >

--- a/version_2.0_API.md
+++ b/version_2.0_API.md
@@ -15,7 +15,7 @@ Depending on the programming language your tool uses (either C, Python or Java),
 
 ### C code
 
-- From version 2.0, Capstone no longer generates details for every disassembled instruction by default. Therefore, if you need those details such as implicit registers read/written or information on operands, you must turn it on right after intializing the engine like in the code below.
+- From version 2.0, Capstone no longer generates details for every disassembled instruction by default. Therefore, if you need those details such as implicit registers read/written or information on operands, you must turn it on right after initializing the engine like in the code below.
 
 {% highlight c %}
 	csh handle;
@@ -50,7 +50,7 @@ Depending on the programming language your tool uses (either C, Python or Java),
 
 ### Python code
 
-From version 2.0, Capstone no longer generates details for every disassembled instruction by default. Therefore, if you need those details such as implicit registers read/written or information on operands, you must turn it on right after intializing the engine like in the code below.
+From version 2.0, Capstone no longer generates details for every disassembled instruction by default. Therefore, if you need those details such as implicit registers read/written or information on operands, you must turn it on right after initializing the engine like in the code below.
 
 {% highlight python %}
 
@@ -65,7 +65,7 @@ From version 2.0, Capstone no longer generates details for every disassembled in
 
 ### Java code
 
-From version 2.0, Capstone no longer generates details for every disassembled instruction by default. Therefore, if you need those details such as implicit registers read/written or information on operands, you must turn it on right after intializing the engine like in the code below.
+From version 2.0, Capstone no longer generates details for every disassembled instruction by default. Therefore, if you need those details such as implicit registers read/written or information on operands, you must turn it on right after initializing the engine like in the code below.
 
 {% highlight java %}
 

--- a/x86reduce.md
+++ b/x86reduce.md
@@ -5,7 +5,7 @@ title: X86-reduce engine
 
 ## Building X86-reduce engine
 
-(Note: at the moment, this *X86-reduce* option is only availabe in the [next branch](https://github.com/aquynh/capstone/tree/next) of our Github repo. It will be integrated into the next release of Capstone)
+(Note: at the moment, this *X86-reduce* option is only availabe in the [next branch](https://github.com/capstone-engine/capstone/tree/next) of our Github repo. It will be integrated into the next release of Capstone)
 
 This documentation introduces how to build the X86 engine of Capstone to be as small as *200KB* - about *60% smaller* than the [diet engine](diet.html) - for embedding purpose.
 

--- a/x86reduce.md
+++ b/x86reduce.md
@@ -5,7 +5,7 @@ title: X86-reduce engine
 
 ## Building X86-reduce engine
 
-(Note: at the moment, this *X86-reduce* option is only availabe in the [next branch](https://github.com/capstone-engine/capstone/tree/next) of our Github repo. It will be integrated into the next release of Capstone)
+(Note: at the moment, this *X86-reduce* option is only available in the [next branch](https://github.com/capstone-engine/capstone/tree/next) of our Github repo. It will be integrated into the next release of Capstone)
 
 This documentation introduces how to build the X86 engine of Capstone to be as small as *200KB* - about *60% smaller* than the [diet engine](diet.html) - for embedding purpose.
 
@@ -16,7 +16,7 @@ Later part presents the APIs related to this reduced mode.
 
 Typically, we use Capstone for usual applications, where the library weight does not really matter. Indeed, as of version *2.1-RC1*, the whole engine is only 1.9 MB including all architectures, and this size raises no issue to most people.
 
-However, to embed Capstone into special enviroments, such as OS kernel driver or firmware, the engine size should be as small as possible due to space restriction. To achieve this object, we must compile Capstone using special methods.
+However, to embed Capstone into special environments, such as OS kernel driver or firmware, the engine size should be as small as possible due to space restriction. To achieve this object, we must compile Capstone using special methods.
 
 To build a tiny engine, consult three documentations below.
 
@@ -31,7 +31,7 @@ For X86 architecture, after applying all of the above techniques, the binary siz
 
 ### 2. Building X86-reduce engine
 
-To reduce the X86 engine even futher, compile Capstone in *X86-reduce* mode to remove some exotic non-critical X86 instruction sets. As a result, this downsizes the engine by *around 60%*, to under *200KB*.
+To reduce the X86 engine even further, compile Capstone in *X86-reduce* mode to remove some exotic non-critical X86 instruction sets. As a result, this downsizes the engine by *around 60%*, to under *200KB*.
 
 Below is the list of instruction sets removed by this option:
 


### PR DESCRIPTION
Change the URLs on the website to point to the new repository and fix some typos discovered with the "codespell" tool.